### PR TITLE
Java8 + Fix paging bug + PR cache optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk7
+  - openjdk8
 
 script: "./gradlew clean test fatjar -Dtoken=$CI_USER_TOKEN -PBUILD_NUMBER=$TRAVIS_BUILD_NUMBER"
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ task wrapper(type: Wrapper) {
 
 idea {
     project {
-        jdkName = '1.7'
+        jdkName = '1.8'
     }
 }
 

--- a/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/Clock.java
+++ b/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/Clock.java
@@ -3,9 +3,6 @@ package com.tzachz.commentcounter;
 import org.joda.time.LocalDate;
 
 public class Clock {
-    public Clock() {
-    }
-
     public LocalDate getLocalDateNow() {
         return LocalDate.now();
     }

--- a/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/PullRequestCache.java
+++ b/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/PullRequestCache.java
@@ -9,6 +9,10 @@ import com.tzachz.commentcounter.apifacade.jsonobjects.GHUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 /**
  * Created with IntelliJ IDEA.
  * User: tzachz
@@ -17,7 +21,7 @@ import org.slf4j.LoggerFactory;
  */
 public class PullRequestCache {
 
-    public static final GHPullRequest UNKNOWN = new GHPullRequest(new GHUser("UNKNOWN", "", ""));
+    static final GHPullRequest UNKNOWN = new GHPullRequest(new GHUser("UNKNOWN", "", ""), "");
 
     private static final Logger logger = LoggerFactory.getLogger(PullRequestCache.class);
 
@@ -27,7 +31,7 @@ public class PullRequestCache {
         this.cache = CacheBuilder.newBuilder()
                 .build(new CacheLoader<String, GHPullRequest>() {
                     @Override
-                    public GHPullRequest load(String key) throws Exception {
+                    public GHPullRequest load(String key) {
                         return facade.getPullRequest(key);
                     }
                 });
@@ -40,5 +44,9 @@ public class PullRequestCache {
             logger.error("exception while getting pull request from cache, for URL: " + url, e);
             return UNKNOWN;
         }
+    }
+
+    public void putAll(Collection<GHPullRequest> prs) {
+        cache.putAll(prs.stream().collect(Collectors.toMap(GHPullRequest::getUrl, Function.identity())));
     }
 }

--- a/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/EmojisResource.java
+++ b/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/EmojisResource.java
@@ -4,14 +4,14 @@ import com.sun.jersey.api.client.GenericType;
 
 import java.util.Map;
 
-public class EmojisResource extends GitHubResource {
+class EmojisResource extends GitHubResource {
 
-    public EmojisResource(Credentials credentials, String url) {
+    EmojisResource(Credentials credentials, String url) {
         super(credentials, url);
     }
 
-    public EmojisMap getEmojisMap() {
-        Map<String, String> emojis = getResource().path("emojis").get(new GenericType<Map<String, String>>() {});
+    EmojisMap getEmojisMap() {
+        final Map<String, String> emojis = getResource().path("emojis").get(new GenericType<Map<String, String>>() {});
         return new EmojisMap(emojis);
     }
 

--- a/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/GitHubApiFacade.java
+++ b/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/GitHubApiFacade.java
@@ -17,13 +17,15 @@ import java.util.Set;
  */
 public interface GitHubApiFacade {
 
-    public GHOrg getOrg(String orgName);
+    GHOrg getOrg(String orgName);
 
-    public Set<GHRepo> getOrgRepos(String orgName);
+    Set<GHRepo> getOrgRepos(String orgName);
 
-    public Collection<GHComment> getRepoComments(String orgName, String repoName, Date since);
+    Collection<GHComment> getRepoComments(String orgName, String repoName, Date since);
 
-    public GHPullRequest getPullRequest(String url);
+    Collection<GHPullRequest> getPullRequests(String orgName, String repoName, Date since);
 
-    public EmojisMap getEmojiMap();
+    GHPullRequest getPullRequest(String url);
+
+    EmojisMap getEmojiMap();
 }

--- a/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/GitHubApiFacadeImpl.java
+++ b/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/GitHubApiFacadeImpl.java
@@ -31,7 +31,7 @@ public class GitHubApiFacadeImpl implements GitHubApiFacade {
                 new EmojisResource(credentials, url));
     }
 
-    GitHubApiFacadeImpl(OrgResource orgResource, OrgRepositoriesResource orgRepositoriesResource, RepoCommentsResource repoCommentsResource, PullRequestResource pullRequestResource, EmojisResource emojisResource) {
+    private GitHubApiFacadeImpl(OrgResource orgResource, OrgRepositoriesResource orgRepositoriesResource, RepoCommentsResource repoCommentsResource, PullRequestResource pullRequestResource, EmojisResource emojisResource) {
         this.orgResource = orgResource;
         this.orgRepositoriesResource = orgRepositoriesResource;
         this.repoCommentsResource = repoCommentsResource;
@@ -52,6 +52,11 @@ public class GitHubApiFacadeImpl implements GitHubApiFacade {
     @Override
     public Collection<GHComment> getRepoComments(String orgName, String repoName, Date since) {
         return repoCommentsResource.getUserComments(orgName, repoName, since);
+    }
+
+    @Override
+    public Collection<GHPullRequest> getPullRequests(String orgName, String repoName, Date since) {
+        return pullRequestResource.getPullRequests(orgName, repoName, since);
     }
 
     @Override

--- a/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/GitHubResource.java
+++ b/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/GitHubResource.java
@@ -24,13 +24,13 @@ public abstract class GitHubResource {
     private final Client client;
     private final String url;
 
-    protected GitHubResource(Credentials credentials, String url) {
+    GitHubResource(Credentials credentials, String url) {
         this.url = url;
         this.client = Client.create();
         this.client.addFilter(new HTTPBasicAuthFilter(credentials.getUsername(), credentials.getPassword()));
     }
 
-    protected WebResource getResource() {
+    WebResource getResource() {
         return client.resource(url);
     }
 
@@ -39,24 +39,21 @@ public abstract class GitHubResource {
         return client.resource(url).get(type);
     }
 
-    protected <T> void scanPages(WebResource resource, GenericType<List<T>> type, PageProcessor<T> processor) {
+    <T> void scanPages(WebResource resource, GenericType<List<T>> type, PageProcessor<T> processor) {
         int totalItems = 0;
-        int pageSize = -1;
         for (int page = 1; page <= MAX_PAGES; page++) {
             logger.debug("Reading page {} from {}", page, resource.toString());
             List<T> events = resource.queryParam("page", Integer.toString(page)).get(type);
             totalItems += events.size();
             processor.process(events);
-            if (events.isEmpty() || events.size() < pageSize) {
+            if (events.isEmpty()) {
                 break;
-            } else {
-                pageSize = events.size();
             }
         }
         logger.info("{} items read from {}", totalItems, resource.toString());
     }
 
     protected interface PageProcessor<T> {
-        public void process(List<T> page);
+        void process(List<T> page);
     }
 }

--- a/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/OAuthCredentials.java
+++ b/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/OAuthCredentials.java
@@ -9,7 +9,7 @@ public class OAuthCredentials implements Credentials {
 
     private final String token;
 
-    public OAuthCredentials(String token) {
+    OAuthCredentials(String token) {
         this.token = token;
     }
 

--- a/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/OrgRepositoriesResource.java
+++ b/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/OrgRepositoriesResource.java
@@ -14,25 +14,19 @@ import java.util.Set;
  * Date: 08/08/13
  * Time: 23:58
  */
-public class OrgRepositoriesResource extends GitHubResource {
+class OrgRepositoriesResource extends GitHubResource {
 
-    public OrgRepositoriesResource(Credentials credentials, String url) {
+    OrgRepositoriesResource(Credentials credentials, String url) {
         super(credentials, url);
     }
 
-    public Set<GHRepo> getRepos(String organization) {
+    Set<GHRepo> getRepos(String organization) {
         final Set<GHRepo> ghRepos = Sets.newHashSet();
-        WebResource resource = getResource()
+        final WebResource resource = getResource()
                 .path("orgs")
                 .path(organization)
                 .path("repos");
-        scanPages(resource, new GenericType<List<GHRepo>>() {}, new PageProcessor<GHRepo>() {
-                    @Override
-                    public void process(List<GHRepo> page) {
-                        ghRepos.addAll(page);
-                    }
-                }
-        );
+        scanPages(resource, new GenericType<List<GHRepo>>() {}, ghRepos::addAll);
         return ghRepos;
     }
 }

--- a/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/OrgResource.java
+++ b/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/OrgResource.java
@@ -8,13 +8,13 @@ import com.tzachz.commentcounter.apifacade.jsonobjects.GHOrg;
  * Date: 10/08/13
  * Time: 14:10
  */
-public class OrgResource extends GitHubResource {
+class OrgResource extends GitHubResource {
 
-    public OrgResource(Credentials credentials, String url) {
+    OrgResource(Credentials credentials, String url) {
         super(credentials, url);
     }
 
-    public GHOrg getOrg(String organization) {
+    GHOrg getOrg(String organization) {
         return getResource()
                 .path("orgs")
                 .path(organization)

--- a/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/PullRequestResource.java
+++ b/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/PullRequestResource.java
@@ -1,14 +1,37 @@
 package com.tzachz.commentcounter.apifacade;
 
+import com.sun.jersey.api.client.GenericType;
+import com.sun.jersey.api.client.WebResource;
 import com.tzachz.commentcounter.apifacade.jsonobjects.GHPullRequest;
 
-public class PullRequestResource extends GitHubResource {
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
 
-    public PullRequestResource(Credentials credentials, String url) {
+class PullRequestResource extends GitHubResource {
+
+    private static final DateFormat SINCE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+    PullRequestResource(Credentials credentials, String url) {
         super(credentials, url);
     }
 
-    public GHPullRequest getPullRequest(String url) {
+    GHPullRequest getPullRequest(String url) {
         return get(url, GHPullRequest.class);
+    }
+
+    Collection<GHPullRequest> getPullRequests(String orgName, String repoName, Date since) {
+        final Collection<GHPullRequest> prs = new ArrayList<>();
+        final WebResource resource = getResource()
+                .path("repos")
+                .path(orgName)
+                .path(repoName)
+                .path("pulls")
+                .queryParam("since", SINCE_FORMAT.format(since));
+        scanPages(resource, new GenericType<List<GHPullRequest>>() {}, prs::addAll);
+        return prs;
     }
 }

--- a/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/RepoCommentsResource.java
+++ b/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/RepoCommentsResource.java
@@ -16,29 +16,24 @@ import java.util.List;
  * User: tzachz
  * Date: 8/8/13
  */
-public class RepoCommentsResource extends GitHubResource {
+class RepoCommentsResource extends GitHubResource {
 
     private static final DateFormat SINCE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
 
-    public RepoCommentsResource(Credentials credentials, String url) {
+    RepoCommentsResource(Credentials credentials, String url) {
         super(credentials, url);
     }
 
-    public Collection<GHComment> getUserComments(String organization, String repoName, Date since) {
+    Collection<GHComment> getUserComments(String organization, String repoName, Date since) {
         final Collection<GHComment> userComments = new ArrayList<>();
-        WebResource resource = getResource()
+        final WebResource resource = getResource()
                 .path("repos")
                 .path(organization)
                 .path(repoName)
                 .path("pulls")
                 .path("comments")
                 .queryParam("since", SINCE_FORMAT.format(since));
-        scanPages(resource, new GenericType<List<GHComment>>() {}, new PageProcessor<GHComment>() {
-            @Override
-            public void process(List<GHComment> page) {
-                userComments.addAll(page);
-            }
-        });
+        scanPages(resource, new GenericType<List<GHComment>>() {}, userComments::addAll);
         return userComments;
     }
 

--- a/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/UserPasswordCredentials.java
+++ b/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/UserPasswordCredentials.java
@@ -8,7 +8,7 @@ public class UserPasswordCredentials implements Credentials {
     private final String user;
     private final String password;
 
-    public UserPasswordCredentials(String user, String password) {
+    UserPasswordCredentials(String user, String password) {
         this.user = user;
         this.password = password;
     }

--- a/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/jsonobjects/GHPullRequest.java
+++ b/github-comment-fetcher/src/main/java/com/tzachz/commentcounter/apifacade/jsonobjects/GHPullRequest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 /**
  * Created with IntelliJ IDEA.
  * User: tzachz
@@ -14,30 +16,33 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class GHPullRequest {
 
     private final GHUser user;
+    private final String url;
 
     @JsonCreator
-    public GHPullRequest(@JsonProperty("user") GHUser user) {
+    public GHPullRequest(@JsonProperty("user") GHUser user, @JsonProperty("url") String url) {
         this.user = user;
+        this.url = url;
     }
 
     public GHUser getUser() {
         return user;
     }
 
+    public String getUrl() {
+        return url;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         GHPullRequest that = (GHPullRequest) o;
-
-        if (user != null ? !user.equals(that.user) : that.user != null) return false;
-
-        return true;
+        return Objects.equals(user, that.user) &&
+                Objects.equals(url, that.url);
     }
 
     @Override
     public int hashCode() {
-        return user != null ? user.hashCode() : 0;
+        return Objects.hash(user, url);
     }
 }

--- a/github-comment-fetcher/src/test/java/com/tzachz/commentcounter/GHCommentBuilder.java
+++ b/github-comment-fetcher/src/test/java/com/tzachz/commentcounter/GHCommentBuilder.java
@@ -11,7 +11,7 @@ public class GHCommentBuilder {
     public Collection<GHComment> createEmptyComments(String... users) {
         List<GHComment> comments = new ArrayList<>();
         for (String user : users) {
-            comments.addAll(Arrays.asList(createComment(user, "")));
+            comments.addAll(Collections.singletonList(createComment(user, "")));
         }
         return comments;
     }

--- a/github-comment-fetcher/src/test/java/com/tzachz/commentcounter/PullRequestCacheTest.java
+++ b/github-comment-fetcher/src/test/java/com/tzachz/commentcounter/PullRequestCacheTest.java
@@ -28,21 +28,21 @@ public class PullRequestCacheTest {
     private PullRequestCache cache;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         initMocks(this);
     }
 
     @Test
-    public void getReturnsFacadeResult() throws Exception {
-        GHPullRequest expected = new GHPullRequest(new GHUser("user1", "", ""));
+    public void getReturnsFacadeResult() {
+        GHPullRequest expected = new GHPullRequest(new GHUser("user1", "", ""), "");
         when(facade.getPullRequest("url")).thenReturn(expected);
         GHPullRequest result = cache.get("url");
         assertThat(result, equalTo(expected));
     }
 
     @Test
-    public void successfulFetchOccursOnce() throws Exception {
-        when(facade.getPullRequest("url")).thenReturn(new GHPullRequest(new GHUser("user1", "", "")));
+    public void successfulFetchOccursOnce() {
+        when(facade.getPullRequest("url")).thenReturn(new GHPullRequest(new GHUser("user1", "", ""), ""));
         cache.get("url");
         cache.get("url");
         verify(facade, times(1)).getPullRequest("url");
@@ -50,7 +50,7 @@ public class PullRequestCacheTest {
     }
 
     @Test
-    public void failedFetchRetriesEveryTime() throws Exception {
+    public void failedFetchRetriesEveryTime() {
         when(facade.getPullRequest("url")).thenThrow(new RuntimeException("can't access url"));
         cache.get("url");
         cache.get("url");
@@ -58,7 +58,7 @@ public class PullRequestCacheTest {
     }
 
     @Test
-    public void failedFetchReturnsUnknownUserPullRequest() throws Exception {
+    public void failedFetchReturnsUnknownUserPullRequest() {
         when(facade.getPullRequest("url")).thenThrow(new RuntimeException("can't access url"));
         GHPullRequest result = cache.get("url");
         assertThat(result, equalTo(PullRequestCache.UNKNOWN));

--- a/github-comment-fetcher/src/test/java/com/tzachz/commentcounter/apifacade/EmojisResourceTest.java
+++ b/github-comment-fetcher/src/test/java/com/tzachz/commentcounter/apifacade/EmojisResourceTest.java
@@ -14,7 +14,7 @@ public class EmojisResourceTest {
     @Rule
     public VMOptsCredentials credentials = new VMOptsCredentials();
 
-    public static final String JSON = "{\n" +
+    private static final String JSON = "{\n" +
             "  \"+1\": \"https://github.global.ssl.fastly.net/images/icons/emoji/+1.png?v5\",\n" +
             "  \"-1\": \"https://github.global.ssl.fastly.net/images/icons/emoji/-1.png?v5\",\n" +
             "  \"100\": \"https://github.global.ssl.fastly.net/images/icons/emoji/100.png?v5\",\n" +
@@ -32,7 +32,7 @@ public class EmojisResourceTest {
     }
 
     @Test
-    public void emojisFetched() throws Exception {
+    public void emojisFetched() {
         EmojisResource resource = new EmojisResource(credentials, credentials.getURL());
         EmojisMap emojisMap = resource.getEmojisMap();
         assertThat(emojisMap.getEmojiCodes(), hasSize(greaterThan(100)));

--- a/github-comment-fetcher/src/test/java/com/tzachz/commentcounter/apifacade/GitHubApiFacadeImplTest.java
+++ b/github-comment-fetcher/src/test/java/com/tzachz/commentcounter/apifacade/GitHubApiFacadeImplTest.java
@@ -48,19 +48,19 @@ public class GitHubApiFacadeImplTest {
     private GitHubApiFacadeImpl apiFacade;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         initMocks(this);
     }
 
     @Test
-    public void getOrgsCallsOrgResource() throws Exception {
+    public void getOrgsCallsOrgResource() {
         final GHOrg org = new GHOrg(ORG_NAME, "http://a.b");
         when(orgResource.getOrg(ORG_NAME)).thenReturn(org);
         assertThat(apiFacade.getOrg(ORG_NAME), is(org));
     }
 
     @Test
-    public void getOrgReposCallsOrgReposResource() throws Exception {
+    public void getOrgReposCallsOrgReposResource() {
         ImmutableSet<GHRepo> repos = ImmutableSet.of(new GHRepo("repo1"), new GHRepo("repo2"));
         when(orgReposResource.getRepos(ORG_NAME)).thenReturn(repos);
         Set<GHRepo> result = apiFacade.getOrgRepos(ORG_NAME);
@@ -68,7 +68,7 @@ public class GitHubApiFacadeImplTest {
     }
 
     @Test
-    public void getCommentsCallsCommentResource() throws Exception {
+    public void getCommentsCallsCommentResource() {
         Date since = new Date();
         ArrayList<GHComment> comments = Lists.newArrayList(createCommentBy("user1"), createCommentBy("user2"));
         when(commentsResource.getUserComments(ORG_NAME, "repo1", since)).thenReturn(comments);
@@ -76,14 +76,14 @@ public class GitHubApiFacadeImplTest {
     }
 
     @Test
-    public void getPullRequestCallsPRResource() throws Exception {
-        GHPullRequest pullRequest = new GHPullRequest(new GHUser("user1", "http://user", "http://avatar"));
+    public void getPullRequestCallsPRResource() {
+        GHPullRequest pullRequest = new GHPullRequest(new GHUser("user1", "http://user", "http://avatar"), "");
         when(pullRequestResource.getPullRequest("http://pr")).thenReturn(pullRequest);
         assertThat(apiFacade.getPullRequest("http://pr"), is(pullRequest));
     }
 
     @Test
-    public void getEmojiMapCallsEmojisResource() throws Exception {
+    public void getEmojiMapCallsEmojisResource() {
         EmojisMap emojisMap = new EmojisMap(ImmutableMap.of(":smile:", "http://smile"));
         when(emojisResource.getEmojisMap()).thenReturn(emojisMap);
         assertThat(emojisResource.getEmojisMap(), is(emojisMap));

--- a/leaderboard-server/src/main/java/com/tzachz/commentcounter/server/LeaderBoardRecord.java
+++ b/leaderboard-server/src/main/java/com/tzachz/commentcounter/server/LeaderBoardRecord.java
@@ -110,6 +110,6 @@ public class LeaderBoardRecord implements Comparable<LeaderBoardRecord> {
 
     @Override
     public int compareTo(LeaderBoardRecord o) {
-        return Integer.valueOf(o.getScore()).compareTo(getScore()); // descending by score
+        return Integer.compare(o.getScore(), getScore()); // descending by score
     }
 }

--- a/leaderboard-server/src/main/java/com/tzachz/commentcounter/server/LeaderBoardService.java
+++ b/leaderboard-server/src/main/java/com/tzachz/commentcounter/server/LeaderBoardService.java
@@ -35,7 +35,7 @@ public class LeaderBoardService extends Service<LeaderBoardServerConfiguration> 
     }
 
     @Override
-    public void run(LeaderBoardServerConfiguration configuration, Environment environment) throws Exception {
+    public void run(LeaderBoardServerConfiguration configuration, Environment environment) {
         GitHubApiFacade apiFacade = getApiFacade(configuration);
         LeaderBoardStore store = getStore(apiFacade);
 

--- a/leaderboard-server/src/main/java/com/tzachz/commentcounter/server/LeaderBoardStore.java
+++ b/leaderboard-server/src/main/java/com/tzachz/commentcounter/server/LeaderBoardStore.java
@@ -1,8 +1,6 @@
 package com.tzachz.commentcounter.server;
 
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.tzachz.commentcounter.Clock;
@@ -13,6 +11,7 @@ import com.tzachz.commentcounter.apifacade.jsonobjects.GHUser;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * Created with IntelliJ IDEA.
@@ -53,12 +52,7 @@ public class LeaderBoardStore {
 
     private Collection<Comment> filterByRecency(List<Comment> comments, int daysBack) {
         final Date since = clock.getLocalDateNow().minusDays(daysBack).toDate();
-        return Collections2.filter(comments, new Predicate<Comment>() {
-            @Override
-            public boolean apply(Comment input) {
-                return !input.getComment().getCreateDate().before(since);
-            }
-        });
+        return comments.stream().filter(input -> !input.getComment().getCreateDate().before(since)).collect(Collectors.toList());
     }
 
     private List<Commenter> aggregate(final Collection<Comment> comments) {

--- a/leaderboard-server/src/main/java/com/tzachz/commentcounter/server/Period.java
+++ b/leaderboard-server/src/main/java/com/tzachz/commentcounter/server/Period.java
@@ -12,7 +12,7 @@ public enum Period {
 
     private final int daysBack;
 
-    private Period(int daysBack) {
+    Period(int daysBack) {
         this.daysBack = daysBack;
     }
 


### PR DESCRIPTION
Bug: sometimes GH returns a non-full page (e.g. 29 elements instead of 30) - shouldn't stop the paging loop. 

Also: reduce number of calls by preemptively fetching last month's PRs for repos with more than 20 (magic number) comments. 

Also - Java8, because enough is enough