### PR TITLE
add jaxb-api as a dependency as it is not already included in jdk9+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ subprojects { project ->
         compile 'com.google.guava:guava:14.0.1'
         compile 'joda-time:joda-time:2.2'
         compile 'org.slf4j:slf4j-api:1.7.5'
+        compile group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
 
         testCompile 'org.hamcrest:hamcrest-library:1.3'
         testCompile 'org.mockito:mockito-core:1.9.0'
@@ -73,4 +74,3 @@ idea.project.ipr {
         provider.node.component.find { it.@name == 'VcsDirectoryMappings' }.mapping.@vcs = 'Git'
     }
 }
-


### PR DESCRIPTION
This may be useful for other people trying to build this project.

My setup is: 
- macOs Monterey v12.4
- Macbook Pro M1 2020

Using (`java --version`):
openjdk 19 2022-09-20
OpenJDK Runtime Environment Homebrew (build 19)
OpenJDK 64-Bit Server VM Homebrew (build 19, mixed mode, sharing)

